### PR TITLE
Use the Power{} cmd to get the current state

### DIFF
--- a/octoprint_psucontrol_tasmota/__init__.py
+++ b/octoprint_psucontrol_tasmota/__init__.py
@@ -111,7 +111,7 @@ class PSUControl_Tasmota(octoprint.plugin.StartupPlugin,
 
         status = None
         try:
-            status = (data['POWER'] == 'ON')
+            status = (data['POWER' + str(self.config['plug'])] == 'ON')
         except KeyError:
             pass
 

--- a/octoprint_psucontrol_tasmota/__init__.py
+++ b/octoprint_psucontrol_tasmota/__init__.py
@@ -111,7 +111,9 @@ class PSUControl_Tasmota(octoprint.plugin.StartupPlugin,
 
         status = None
         try:
-            status = (data['POWER' + str(self.config['plug'])] == 'ON')
+            # On some devices it seems to add the plug number, on others it doesn't.
+            # So check for both variants.
+            status = ((data.get('POWER' + str(self.config['plug'])) or data.get('POWER')) == 'ON')
         except KeyError:
             pass
 

--- a/octoprint_psucontrol_tasmota/__init__.py
+++ b/octoprint_psucontrol_tasmota/__init__.py
@@ -101,6 +101,7 @@ class PSUControl_Tasmota(octoprint.plugin.StartupPlugin,
 
 
     def get_psu_state(self):
+        # First try the "Power"-cmd
         cmd = "Power{}".format(self.config['plug'])
 
         response = self.send(cmd)
@@ -110,13 +111,30 @@ class PSUControl_Tasmota(octoprint.plugin.StartupPlugin,
 
         status = None
         try:
-            status = (data['POWER' + str(self.config['plug'])] == 'ON')
+            status = (data['POWER'] == 'ON')
+        except KeyError:
+            pass
+
+        if status != None:
+            return status
+
+        # If that didn't work, try the "Status"-cmd
+        cmd = "Status 0"
+
+        response = self.send(cmd)
+        if not response:
+            return False
+        data = response.json()
+
+        status = None
+        try:
+            status = (data['StatusSTS']['POWER' + str(self.config['plug'])] == 'ON')
         except KeyError:
             pass
 
         if status == None and self.config['plug'] == 1:
             try:
-                status = (data['POWER'] == 'ON')
+                status = (data['StatusSTS']['POWER'] == 'ON')
             except KeyError:
                 pass
 

--- a/octoprint_psucontrol_tasmota/__init__.py
+++ b/octoprint_psucontrol_tasmota/__init__.py
@@ -101,7 +101,7 @@ class PSUControl_Tasmota(octoprint.plugin.StartupPlugin,
 
 
     def get_psu_state(self):
-        cmd = "Status 0"
+        cmd = "Power{}".format(self.config['plug'])
 
         response = self.send(cmd)
         if not response:
@@ -110,13 +110,13 @@ class PSUControl_Tasmota(octoprint.plugin.StartupPlugin,
 
         status = None
         try:
-            status = (data['StatusSTS']['POWER' + str(self.config['plug'])] == 'ON')
+            status = (data['POWER' + str(self.config['plug'])] == 'ON')
         except KeyError:
             pass
 
         if status == None and self.config['plug'] == 1:
             try:
-                status = (data['StatusSTS']['POWER'] == 'ON')
+                status = (data['POWER'] == 'ON')
             except KeyError:
                 pass
 


### PR DESCRIPTION
Hi,

I noticed that a newer Tasmota version (Tasmota 12.3.1) doesn't work anymore on my plug. It can no longer get the psu status.
After investigating it, I noticed that `Status 0` doesn't return the json structure assumed in the plugin.

With a call to ` cmd = "Power{}".format(self.config['plug'])`, which only returns the status and nothing else, it works flawlessly.

It now first tries the new way and only if it did not work tries the old way after that. This should avoid any possible backward compatibility issue. (Not sure if there is any issue, but  better safe than sorry...)

